### PR TITLE
Fix configuration example

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -36,8 +36,8 @@ This extension has a lot of configuration options:
 ```php
     # WebSockets server
     webSockets:
-        clients:
-            storage:
+        storage:
+            clients:
                 driver: @clients.driver.memory  // Here you can pass service name of your clients storage driver implementation
                 ttl:    0                       // If your driver support TTL, here you can define it
         // Main server configuration


### PR DESCRIPTION
`clients` should be nested under `storage`, not the other way round.

Relevant extension code: https://github.com/ipublikuj/websockets/blob/ec9580ed98970270cce0870f3934a100924e8195/src/DI/WebSocketsExtension.php#L39