### PR TITLE
ServerCommand: set defaultName

### DIFF
--- a/src/Commands/ServerCommand.php
+++ b/src/Commands/ServerCommand.php
@@ -21,7 +21,8 @@ use Symfony\Component\Console\Style;
  */
 class ServerCommand extends Console\Command\Command
 {
-
+    protected static $defaultName = 'ipub:websockets:start';
+	
 	/** @var Server\Server */
 	private $server;
 
@@ -50,7 +51,7 @@ class ServerCommand extends Console\Command\Command
 	protected function configure(): void
 	{
 		$this
-			->setName('ipub:websockets:start')
+			->setName(self::$defaultName)
 			->setDescription('Start WebSocket server.');
 	}
 


### PR DESCRIPTION
Symfony command nees to have default name othewise it throws an error:

```
Command "IPub\WebSockets\Commands\ServerCommand" missing tag "console.command[name]" or variable "$defaultName".
```